### PR TITLE
Less deps, fixes and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,20 @@ perl:
   - "5.26"
   - "blead"
 
+env:
+  - WITHOUT_RECOMMENDS=0
+  - WITHOUT_RECOMMENDS=1
+
 matrix:
   allow_failures:
     - perl: blead
+  exclude:
+    - perl: "5.10"
+      env: WITHOUT_RECOMMENDS=1
+    - perl: "5.12"
+      env: WITHOUT_RECOMMENDS=1
+    - perl: "5.14"
+      env: WITHOUT_RECOMMENDS=1
 
 sudo: false
 
@@ -27,6 +38,11 @@ before_install:
   - build-dist
   - cd $BUILD_DIR
   - cpan-install ExtUtils::MakeMaker~6.68
+  - if [ "$WITHOUT_RECOMMENDS" = "1" ]; then
+        for f in "META.json" "META.yml" "Makefile.PL"; do
+            cat $f | grep -P -v 'Filter::signatures|MIME::Detect|Text::CleanFragment|^recommends:' > $$ && mv -f $$ $f;
+        done;
+    fi
   - cpan-install --deps
 
 script:

--- a/META.json
+++ b/META.json
@@ -34,12 +34,14 @@
          "requires" : {
             "Carp" : "0",
             "Data::Dumper" : "0",
-            "Filter::signatures" : "0.04",
             "JSON" : "0",
-            "MIME::Detect" : "0",
             "Test::More" : "0",
-            "Text::CleanFragment" : "0",
-            "perl" : "5.006"
+            "perl" : "5.010"
+         },
+         "recommends" : {
+            "Filter::signatures" : "0.10",
+            "MIME::Detect" : "0",
+            "Text::CleanFragment" : "0"
          }
       }
    },

--- a/META.yml
+++ b/META.yml
@@ -24,12 +24,13 @@ provides:
 requires:
   Carp: '0'
   Data::Dumper: '0'
-  Filter::signatures: '0.04'
   JSON: '0'
-  MIME::Detect: '0'
   Test::More: '0'
+  perl: '5.010'
+recommends:
+  Filter::signatures: '0.10'
+  MIME::Detect: '0'
   Text::CleanFragment: '0'
-  perl: '5.006'
 resources:
   license: http://dev.perl.org/licenses/
   repository: git://github.com/Corion/HTTP-Upload-FlowJs.git

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,7 +42,16 @@ my %module = (
                 file    => $main_file,
                 version => $main_version,
             }
-        }
+        },
+        prereqs => {
+            runtime => {
+                recommends => {
+                    'Filter::signatures' => '0.10', # For compatibility with Perl < 5.22
+                    'MIME::Detect'      => 0, # for user generated content
+                    'Text::CleanFragment' => 0, # we want to create clean local filenames
+                },
+            },
+        },
     },
     LICENSE             => 'perl',
     PL_FILES            => {},
@@ -51,13 +60,9 @@ my %module = (
     },
     PREREQ_PM => {
         'Carp' => 0,
-        'Filter::signatures' => '0.10', # For compatibility with Perl < 5.22
         'Test::More' => 0,
         'JSON'           => 0, # Just for the interface
         'Data::Dumper'      => 0, # for printing clean values to logfiles
-        
-        'MIME::Detect'      => 0, # for user generated content
-        'Text::CleanFragment' => 0, # we want to create clean local filenames
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'HTTP-Upload-FlowJs-*' },

--- a/example/plack-server.psgi
+++ b/example/plack-server.psgi
@@ -42,6 +42,7 @@ my @parameter_names = (
     'flowChunkNumber', # The index of the chunk in the current upload.
                        # First chunk is 1 (no base-0 counting here).
     'flowTotalChunks', # The total number of chunks.
+    'flowCurrentChunkSize', # Current chunk size
     'flowChunkSize', # The general chunk size. Using this value and
                      # flowTotalSize you can calculate the total number of
                      # chunks. Please note that the size of the data received in

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -464,7 +464,11 @@ sub validateRequest {
     }
 
     for my $param (qw(flowChunkSize flowCurrentChunkSize)) {
-        if( exists $info->{ $param } and $info->{ $param } < $self->{ minChunkSize } ) {
+        if( exists $info->{ $param } and $info->{ $param } < $self->{ minChunkSize }
+            and ( $info->{flowChunkNumber} < $info->{flowTotalChunks} # only last chunk could be smaller
+               or $info->{flowTotalChunks} <= 1                       # when total chunks > 1
+            )
+        ) {
             $min_max_error = 1;
             push @invalid, sprintf 'Uploaded chunk [%d] of file [%s] is too small [%d], allowed is [%d]',
                                 $info->{flowChunkNumber},

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -163,11 +163,21 @@ or L<Dancer> for that.
 
 =over 4
 
+B<incomingDirectory> - path for the temporary upload parts
+
+Required
+
 B<maxChunkCount> - hard maximum chunks allowed for a single upload
+
+Default 1000
 
 B<maxFileSize> - hard maximum total file size for a single upload
 
+Default 10_000_000
+
 B<maxChunkSize> - hard maximum chunk size for a single chunk
+
+Default 1048576
 
 B<minChunkSize> - hard minimum chunk size for a single chunk
 
@@ -189,6 +199,8 @@ L</jsConfig> equal to C<maxChunkSize / 2>.
 
 B<simultaneousUploads> - simultaneously allowed uploads per file
 
+Default 3
+
 This is just an indication to the Javascript C<flow.js> client
 if you pass it the configuration from this object. This is not enforced
 in any way yet.
@@ -202,7 +214,7 @@ upload as complete with C<< $flowjs->uploadComplete >>.
 
 B<fileParameterName> - The name of the multipart POST parameter to use for the file chunk
 
-Default: file
+Default file
 
 =back
 

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -503,7 +503,7 @@ sub validateRequest {
 
     } elsif( ! $min_max_error and ($info->{ flowCurrentChunkSize } || 0 ) > $self->expectedChunkSize( $info )) {
         # Uploaded chunk is a middle or end chunk but is too large
-        push @invalid, sprintf 'Uploaded chunk [%s] is too small ([%d]) expect [%d]',
+        push @invalid, sprintf 'Uploaded chunk [%s] is too large ([%d]) expect [%d]',
                             $info->{flowChunkNumber},
                             $info->{flowCurrentChunkSize},
                             $self->expectedChunkSize( $info ),

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -1,12 +1,9 @@
 package HTTP::Upload::FlowJs;
 use strict;
 use Carp qw(croak);
-use Filter::signatures;
-no warnings 'experimental::signatures';
-use feature 'signatures';
-use Text::CleanFragment 'clean_fragment';
+
+use HTTP::Upload::FlowJs::Utils qw(clean_fragment mime_detect);
 use Data::Dumper;
-use MIME::Detect;
 
 use vars '$VERSION';
 $VERSION = '0.01';
@@ -200,7 +197,8 @@ fairly disk-intensive on some systems.
 
 =cut
 
-sub new( $class, %options ) {
+sub new {
+    my ( $class, %options ) = @_;
     croak "Need a directory name for the temporary upload parts"
         unless $options{ incomingDirectory };
 
@@ -210,17 +208,21 @@ sub new( $class, %options ) {
     $options{ minChunkSize } ||= 1024;
     $options{ simultaneousUploads } ||= 3;
     $options{ maxPendingUploads } ||= 1000;
-    $options{ mime } ||= MIME::Detect->new();
+    $options{ mime } ||= mime_detect();
     $options{ allowedContentType } ||= sub { 1 };
 
     bless \%options => $class;
 };
 
-sub incomingDirectory( $self ) {
+sub incomingDirectory {
+    my ($self) = @_;
+
     $self->{incomingDirectory};
 };
 
-sub mime($self) {
+sub mime {
+    my ($self) = @_;
+
     $self->{mime}
 };
 
@@ -235,7 +237,9 @@ object for inclusion with the JS side of the world
 
 =cut
 
-sub jsConfig( $self, %override ) {
+sub jsConfig {
+    my ( $self, %override ) = @_;
+
     {
         map { $_ => $self->{$_} } (qw(
             chunkSize
@@ -249,7 +253,9 @@ sub jsConfig( $self, %override ) {
     }
 }
 
-sub jsConfigStr( $self, %override ) {
+sub jsConfigStr {
+    my ( $self, %override ) = @_;
+
     encode_json($self->js_Config(%override))
 }
 
@@ -269,7 +275,9 @@ check previously stored information.
 
 =cut
 
-sub validateRequest( $self, $method, $info, $sessionId=undef ) {
+sub validateRequest {
+    my ( $self, $method, $info, $sessionId ) = @_;
+
     # Validate the input somewhat
     local $Data::Dumper::Useqq = 1;
 
@@ -424,7 +432,11 @@ chunk as indicated by C<$info>.
 
 =cut
 
-sub expectedChunkSize( $self, $info, $index=0 ) {
+sub expectedChunkSize {
+    my ( $self, $info, $index ) = @_;
+
+    $index //= 0;
+
     # If we are not the last chunk, we need to be what the information says:
     $index ||= $info->{flowChunkNumber};
     if( ! $info->{flowTotalChunks}) {
@@ -460,7 +472,9 @@ is passed, it will remove all partial files from the directory.
 
 =cut
 
-sub resetUploadDirectories( $self, $wipe=undef ) {
+sub resetUploadDirectories {
+    my ( $self, $wipe ) = @_;
+
     my $dir = $self->{incomingDirectory};
     if( ! -d $dir ) {
         mkdir $dir
@@ -486,7 +500,11 @@ the current chunk.
 
 =cut
 
-sub chunkName( $self, $info, $sessionPrefix=undef, $index=0 ) {
+sub chunkName {
+    my ( $self, $info, $sessionPrefix, $index ) = @_;
+
+    $index //= 0;
+
     my $dir = $self->{incomingDirectory};
     $sessionPrefix = '' unless defined $sessionPrefix;
     my $chunkname = sprintf "%s/%s%s.part%03d",
@@ -516,7 +534,11 @@ sub chunkName( $self, $info, $sessionPrefix=undef, $index=0 ) {
 
 =cut
 
-sub chunkOK($self, $info, $sessionPrefix=undef, $index=0) {
+sub chunkOK {
+    my ( $self, $info, $sessionPrefix, $index ) = @_;
+
+    $index //= 0;
+
     my @messages = $self->validateRequest( 'GET', $info, $sessionPrefix );
     if( @messages ) {
         return 500, @messages
@@ -539,7 +561,9 @@ sub chunkOK($self, $info, $sessionPrefix=undef, $index=0) {
 
 =cut
 
-sub uploadComplete( $self, $info, $sessionPrefix=undef ) {
+sub uploadComplete {
+    my ( $self, $info, $sessionPrefix) = @_;
+
     my $complete = 1;
     for( 1.. $info->{ flowTotalChunks }) {
         my( $status, @messages ) = $self->chunkOK( $info, $sessionPrefix, $_ ) ;
@@ -561,7 +585,11 @@ and the index are optional.
 
 =cut
 
-sub chunkFh( $self, $info, $sessionPrefix=undef, $index=0 ) {
+sub chunkFh {
+    my ( $self, $info, $sessionPrefix, $index ) = @_;
+
+    $index //= 0;
+
     my %info = %$info;
     $info{ chunkNumber } = $index if $index;
     my $chunkname = $self->chunkName( \%info, $sessionPrefix, $index );
@@ -580,7 +608,11 @@ and the index are optional.
 
 =cut
 
-sub chunkContent( $self, $info, $sessionPrefix=undef, $index=0 ) {
+sub chunkContent {
+    my ( $self, $info, $sessionPrefix, $index ) = @_;
+
+    $index //= 0;
+
     my $chunk = $self->chunkFh( $info, $sessionPrefix, $index );
     local $/;
     <$chunk>
@@ -597,7 +629,9 @@ this MIME type. Unrecognized files will be blocked.
 
 =cut
 
-sub disallowedContentType( $self, $info, $session=undef ) {
+sub disallowedContentType {
+    my ( $self, $info, $session) = @_;
+
     my( $content_type, $image_ext ) = $self->sniffContentType($info,$session);
     if( !defined $content_type ) {
         # we need more chunks uploaded to check the content type
@@ -639,13 +673,15 @@ check the upload type.
 
 =cut
 
-sub sniffContentType( $self, $info, $sessionPrefix=undef ) {
+sub sniffContentType {
+    my ( $self, $info, $sessionPrefix ) = @_;
+
     my( $content_type, $image_ext );
 
     my( $status, @messages ) = $self->chunkOK( $info, $sessionPrefix, 1 );
     if( 200 == $status ) {
         my $fh = $self->chunkFh( $info, $sessionPrefix, 1 );
-        my $t = $self->mime->mime_type($fh);
+        my $t = $self->mime->mime_type($fh) if $self->mime;
         if( $t ) {
             $content_type = $t->mime_type;
             $image_ext    = $t->extension;
@@ -686,7 +722,9 @@ sub sniffContentType( $self, $info, $sessionPrefix=undef ) {
 
 =cut
 
-sub combineChunks( $self, $info, $sessionPrefix, $target_fh, $digest=undef ) {
+sub combineChunks {
+    my ( $self, $info, $sessionPrefix, $target_fh, $digest ) = @_;
+
     my @unlink_chunks;
     my $ok = 1;
     for( 1.. $info->{ flowTotalChunks }) {
@@ -712,7 +750,9 @@ than one chunk.
 
 =cut
 
-sub pendingUploads( $self ) {
+sub pendingUploads {
+    my ($self) = @_;
+
     my @files;
     my %uploads;
 
@@ -752,7 +792,12 @@ It defaults to C<time>.
 
 =cut
 
-sub staleUploads( $self, $timeout = 3600, $now = time() ) {
+sub staleUploads {
+    my ( $self, $timeout, $now ) = @_;
+
+    $timeout //= 3600;
+    $now     //= time;
+
     my $cutoff = $now - $timeout;
     my %mtime;
     my @files = reverse sort $self->pendingUploads();
@@ -796,7 +841,12 @@ will delete files from another instance.
 
 =cut
 
-sub purgeStaleOrInvalid($self, $timeout = 3600, $now = time() ) {
+sub purgeStaleOrInvalid {
+    my ($self, $timeout, $now ) = @_;
+
+    $timeout //= 3600;
+    $now     //= time;
+
     # First, kill off all stale files
     my @errors;
     for my $f ($self->staleUploads( $timeout, $now )) {

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -497,7 +497,7 @@ sub validateRequest {
                             $self->{maxChunkSize},
                             ;
 
-    } elsif( ! $min_max_error and ($info->{ flowCurrentChunkSize } || 0 ) < $self->expectedChunkSize( $info )) {
+    } elsif( ! $min_max_error and $info->{ flowCurrentChunkSize } < $self->expectedChunkSize( $info ) ) {
         # Uploaded chunk is a middle or end chunk but is too small
         push @invalid, sprintf 'Uploaded chunk [%s] is too small ([%d]) expect [%d]',
                             $info->{flowChunkNumber},
@@ -505,7 +505,15 @@ sub validateRequest {
                             $self->expectedChunkSize( $info ),
                             ;
 
-    } elsif( ! $min_max_error and ($info->{ flowCurrentChunkSize } || 0 ) > $self->expectedChunkSize( $info )) {
+    } elsif( ! $min_max_error and $method eq 'POST' and $info->{ localChunkSize } < $info->{ flowCurrentChunkSize } ) {
+        # Real uploaded chunk is smaller than provided chunk upload size
+        push @invalid, sprintf 'Uploaded chunk [%s] is too small ([%d]) expect [%d]',
+                            $info->{flowChunkNumber},
+                            $info->{localChunkSize},
+                            $info->{flowCurrentChunkSize},
+                            ;
+
+    } elsif( ! $min_max_error and $info->{ flowCurrentChunkSize } > $self->expectedChunkSize( $info ) ) {
         # Uploaded chunk is a middle or end chunk but is too large
         push @invalid, sprintf 'Uploaded chunk [%s] is too large ([%d]) expect [%d]',
                             $info->{flowChunkNumber},

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -679,20 +679,25 @@ sub sniffContentType {
     my( $content_type, $image_ext );
 
     my( $status, @messages ) = $self->chunkOK( $info, $sessionPrefix, 1 );
-    if( 200 == $status ) {
-        my $fh = $self->chunkFh( $info, $sessionPrefix, 1 );
-        my $t = $self->mime->mime_type($fh) if $self->mime;
-        if( $t ) {
-            $content_type = $t->mime_type;
-            $image_ext    = $t->extension;
-        } else {
-            $content_type = '';
-            $image_ext    = '';
-        };
 
-    } else {
-        # Chunk 1 not uploaded/complete yet
+    if ( $self->mime ) {
+        if( 200 == $status ) {
+
+            my $fh = $self->chunkFh( $info, $sessionPrefix, 1 );
+            my $t = $self->mime->mime_type($fh);
+            if( $t ) {
+                $content_type = $t->mime_type;
+                $image_ext    = $t->extension;
+            } else {
+                $content_type = '';
+                $image_ext    = '';
+            };
+
+        } else {
+            # Chunk 1 not uploaded/complete yet
+        }
     }
+
     return $content_type, $image_ext;
 };
 

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -406,14 +406,6 @@ sub validateRequest {
                             $self->expectedChunkSize( $info ),
                             ;
 
-    } elsif( ($info->{ flowChunkSize } || 0 ) < $self->expectedChunkSize( $info )) {
-        # Uploaded chunk is a middle or end chunk but is too large
-        push @invalid, sprintf 'Uploaded chunk [%s] is too small ([%d]) expect [%d]',
-                            $info->{flowChunkNumber},
-                            $info->{flowChunkSize},
-                            $self->expectedChunkSize( $info ),
-                            ;
-
     } else {
         # Everything is OK with the chunk size and file size, I guess.
 

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -233,7 +233,7 @@ sub new {
     $options{ maxChunkCount } ||= 1000;
     $options{ maxFileSize } ||= 10_000_000;
     $options{ maxChunkSize } ||= 1024*1024;
-    $options{ minChunkSize } ||= 1024;
+    $options{ minChunkSize } //= 1024;
     $options{ forceChunkSize } //= 1;
     $options{ simultaneousUploads } ||= 3;
     $options{ fileParameterName } ||= 'file';
@@ -386,7 +386,7 @@ sub validateRequest {
 
     # Numbers should be numbers
     for my $param (qw(flowChunkNumber flowTotalChunks flowChunkSize flowTotalSize flowCurrentChunkSize)) {
-        if( exists $info->{ $param } and ! $info->{ $param } =~ /^[0-9]+$/) {
+        if( exists $info->{ $param } and $info->{ $param } !~ /^[0-9]+$/) {
             push @invalid, sprintf 'Parameter [%s] should be numeric, but is [%s]; set to 0',
                                 $param,
                                 $info->{$param}
@@ -556,6 +556,10 @@ sub expectedChunkSize {
     } elsif( ! $info->{flowChunkSize} ) {
         # No size, we guess it'll be zero:
         return 0
+
+    } elsif( ! $info->{flowTotalSize} ) {
+        # Total size is zero
+        return 0;
 
     } else {
         # The last chunk can be smaller or sized just like all the chunks

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -8,6 +8,7 @@ use Data::Dumper;
 use vars '$VERSION';
 $VERSION = '0.01';
 
+use feature qw(state);
 use JSON qw(encode_json decode_json);
 
 =head1 NAME
@@ -371,7 +372,7 @@ sub validateRequest {
         if( exists $info->{ $param } and ! $info->{ $param } =~ /^[0-9]+$/) {
             push @invalid, sprintf 'Parameter [%s] should be numeric, but is [%s]; set to 0',
                                 $param,
-                                Dumper $info->{$param}
+                                $info->{$param}
                                 ;
             $info->{ $param } = 0;
         };
@@ -403,7 +404,7 @@ sub validateRequest {
         if( exists $info->{ $param } and $info->{ $param } =~ m![/\\]! ) {
             push @invalid, sprintf 'Parameter [%s] contains invalid path segments',
                                 $param,
-                                Dumper $info->{$param}
+                                $info->{$param}
                                 ;
         };
     };
@@ -414,7 +415,7 @@ sub validateRequest {
         if( exists $info->{ $param } and $info->{ $param } =~ m![/\\]\.\.[/\\]! ) {
             push @invalid, sprintf 'Parameter [%s] contains invalid upward path segments [%s]',
                                 $param,
-                                Dumper $info->{$param}
+                                $info->{$param}
                                 ;
         };
     };
@@ -424,7 +425,7 @@ sub validateRequest {
         if( exists $info->{ $param } and $info->{ $param } =~ m![\x00-\x1f]! ) {
             push @invalid, sprintf 'Parameter [%s] contains control characters [%s]',
                                 $param,
-                                Dumper $info->{$param}
+                                $info->{$param}
                                 ;
         };
     };

--- a/lib/HTTP/Upload/FlowJs.pm
+++ b/lib/HTTP/Upload/FlowJs.pm
@@ -222,7 +222,7 @@ sub new {
     $options{ maxFileSize } ||= 10_000_000;
     $options{ maxChunkSize } ||= 1024*1024;
     $options{ minChunkSize } ||= 1024;
-    $options{ forceChunkSize } ||= 1;
+    $options{ forceChunkSize } //= 1;
     $options{ simultaneousUploads } ||= 3;
     $options{ fileParameterName } ||= 'file';
     $options{ mime } ||= mime_detect();
@@ -263,28 +263,31 @@ object for inclusion with the JS side of the world
 sub jsConfig {
     my ( $self, %override ) = @_;
 
+
     # The last uploaded chunk will be at least this size and up to two the size
     # when forceChunkSize is false
     my $chunkSize = $self->{maxChunkSize};
     $chunkSize = $chunkSize / 2 unless $self->{forceChunkSize};
 
-    {
-        map { $_ => $self->{$_} } (qw(
-            simultaneousUploads
-            forceChunkSize
-        )),
+    +{
+        (
+            map { $_ => $self->{$_} } (qw(
+                simultaneousUploads
+                forceChunkSize
+            ))
+        ),
         chunkSize => $chunkSize,
         testChunks => 1,
         withCredentials => 1,
         uploadMethod => 'POST',
         %override,
-    }
+    };
 }
 
 sub jsConfigStr {
     my ( $self, %override ) = @_;
 
-    encode_json($self->js_Config(%override))
+    encode_json($self->jsConfig(%override))
 }
 
 =head2 C<< $flowjs->params >>

--- a/lib/HTTP/Upload/FlowJs/Utils.pm
+++ b/lib/HTTP/Upload/FlowJs/Utils.pm
@@ -1,0 +1,83 @@
+package HTTP::Upload::FlowJs::Util;
+
+use strict;
+use warnings;
+
+use vars qw(@ISA @EXPORT_OK);
+
+require Exporter;
+@ISA = qw(Exporter);
+@EXPORT_OK = qw(clean_fragment mime_detect);
+
+use feature "fc";
+use Unicode::Normalize;
+
+#
+# mime detect
+#
+
+my $mime_detect_fallback;
+sub mime_detect {
+    if ( not defined $mime_detect_fallback ) {
+        eval {
+            require MIME::Detect;
+            $mime_detect_fallback = 0;
+            1;
+        } or do {
+            $mime_detect_fallback = 1;
+        }
+    }
+
+    if ( $mime_detect_fallback ) {
+        return undef
+    }
+    elsif ( defined $mime_detect_fallback ) {
+        return MIME::Detect->new(@_);
+    }
+}
+
+
+#
+# clean_fragment
+#
+
+my $clean_fragment_fallback;
+sub clean_fragment {
+    if ( not defined $clean_fragment_fallback ) {
+        eval {
+            require Text::CleanFragment;
+            $clean_fragment_fallback = 0;
+            1;
+        } or do {
+            $clean_fragment_fallback = 1;
+        }
+    }
+
+    if ( $clean_fragment_fallback ) {
+        return clean_fragment_fallback(@_);
+    }
+    elsif ( defined $clean_fragment_fallback ) {
+        return Text::CleanFragment::clean_fragment(@_);
+    }
+}
+
+sub clean_fragment_fallback {
+    my @strings = @_;
+
+    for( @strings ) {
+        $_ = NFKD($_);
+        s/([\x{80}-\x{300}])/fc($1)/eg;
+
+        tr/['"\x{2019}]//d;     # Eliminate apostrophes
+        tr/\x{300}-\x{36f}//d;
+        s/[^a-zA-Z0-9.-]+/_/g;  # Replace all non-ascii by underscores, including whitespace
+        s/-+/-/g;               # Squash dashes
+        s/_(?:-_)+/-/g;         # Squash _-_ and _-_-_ to -
+        s/^[-_]+//;             # Eliminate leading underscores
+        s/[-_]+$//;             # Eliminate trailing underscores
+        s/_(\W)/$1/;            # No underscore before - or .
+     };
+    wantarray ? @strings : $strings[0];
+};
+
+1;

--- a/lib/HTTP/Upload/FlowJs/Utils.pm
+++ b/lib/HTTP/Upload/FlowJs/Utils.pm
@@ -1,4 +1,4 @@
-package HTTP::Upload::FlowJs::Util;
+package HTTP::Upload::FlowJs::Utils;
 
 use strict;
 use warnings;
@@ -9,55 +9,35 @@ require Exporter;
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(clean_fragment mime_detect);
 
-use feature "fc";
+use feature qw(fc);
 use Unicode::Normalize;
 
-#
-# mime detect
-#
-
-my $mime_detect_fallback;
-sub mime_detect {
-    if ( not defined $mime_detect_fallback ) {
-        eval {
-            require MIME::Detect;
-            $mime_detect_fallback = 0;
-            1;
-        } or do {
-            $mime_detect_fallback = 1;
+BEGIN {
+    # clean_fragment
+    {
+        eval { require Text::CleanFragment };
+        my $subname = __PACKAGE__ . '::clean_fragment';
+        no strict 'refs';
+        if ( $@ ) {
+            *{$subname} = \&clean_fragment_fallback;
+        }
+        else {
+            *{$subname} = \&Text::CleanFragment::clean_fragment;
         }
     }
 
-    if ( $mime_detect_fallback ) {
-        return undef
-    }
-    elsif ( defined $mime_detect_fallback ) {
-        return MIME::Detect->new(@_);
-    }
-}
 
-
-#
-# clean_fragment
-#
-
-my $clean_fragment_fallback;
-sub clean_fragment {
-    if ( not defined $clean_fragment_fallback ) {
-        eval {
-            require Text::CleanFragment;
-            $clean_fragment_fallback = 0;
-            1;
-        } or do {
-            $clean_fragment_fallback = 1;
+    # mime_detect
+    {
+        eval { require MIME::Detect };
+        my $subname = __PACKAGE__ . '::mime_detect';
+        no strict 'refs';
+        if ( $@ ) {
+            *{$subname} = sub { undef };
         }
-    }
-
-    if ( $clean_fragment_fallback ) {
-        return clean_fragment_fallback(@_);
-    }
-    elsif ( defined $clean_fragment_fallback ) {
-        return Text::CleanFragment::clean_fragment(@_);
+        else {
+            *{$subname} = sub { MIME::Detect->new(@_) };
+        }
     }
 }
 

--- a/lib/HTTP/Upload/FlowJs/Utils.pm
+++ b/lib/HTTP/Upload/FlowJs/Utils.pm
@@ -9,7 +9,7 @@ require Exporter;
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(clean_fragment mime_detect);
 
-use feature qw(fc);
+use if $] >= 5.016, feature => qw(fc);
 use Unicode::Normalize;
 
 BEGIN {
@@ -19,6 +19,8 @@ BEGIN {
         my $subname = __PACKAGE__ . '::clean_fragment';
         no strict 'refs';
         if ( $@ ) {
+            die "Need Text::CleanFragment or Perl >= 5.016\n\n" if $] < 5.016;
+
             *{$subname} = \&clean_fragment_fallback;
         }
         else {

--- a/t/002_http_upload_disallowedContentType.t
+++ b/t/002_http_upload_disallowedContentType.t
@@ -1,12 +1,22 @@
 #!perl -w
 use strict;
 use warnings;
-use Test::More tests => 3;
+use Test::More;
 use Data::Dumper;
 use File::Temp 'tempdir';
 use File::Copy 'cp';
 
 use HTTP::Upload::FlowJs;
+
+BEGIN {
+    eval 'use MIME::Detect';
+    if( $@ ) {
+        plan skip_all => 'No MIME::Detect installed';
+    }
+    else {
+        plan tests => 3;
+    }
+}
 
 my $tempdir = tempdir();
 

--- a/t/002_http_upload_disallowedContentType.t
+++ b/t/002_http_upload_disallowedContentType.t
@@ -33,6 +33,7 @@ my $flowjs = HTTP::Upload::FlowJs->new(
 my %info = (
         flowChunkNumber => 1,
         flowChunkSize => -s $0,
+        flowCurrentChunkSize => -s $0,
         flowFilename => 'IMG_7363.JPG',
         flowIdentifier => '2226376-IMG_7363JPG',
         flowRelativePath => 'IMG_7363.JPG',

--- a/t/003_http_upload_flowjs.t
+++ b/t/003_http_upload_flowjs.t
@@ -224,8 +224,8 @@ for my $chunk (@parts) {
             is $ext, 'png', "Once we see the first chunk, we find the correct extension";
         }
         else {
-            is $content_type, '', "Unknown content type or no MIME::Detect installed";
-            is $ext, '', "Unknown extension or no MIME::Detect installed";
+            is $content_type, undef, "Unknown content type or no MIME::Detect installed";
+            is $ext, undef, "Unknown extension or no MIME::Detect installed";
         }
     } else {
         is $content_type, undef, "Until we see the first chunk, we don't know the content type";
@@ -318,7 +318,7 @@ for my $chunk (@parts, 2..parts) {
             is $res, 'image/png', "Once we see the first chunk, we find the file is disallowed";
         }
         else {
-            is $res, '1', "Unknown content type or no MIME::Detect installed";
+            is $res, undef, "Unknown content type or no MIME::Detect installed";
         }
     } else {
         is $res, undef, "Until we see the first chunk, we don't know if the file is disallowed";

--- a/t/003_http_upload_flowjs.t
+++ b/t/003_http_upload_flowjs.t
@@ -8,7 +8,7 @@ use HTTP::Upload::FlowJs;
 use File::Temp qw(tempdir);
 use ExtUtils::Command();
 
-my $tempdir = tempdir();
+my $tempdir = tempdir( );
 END {
     if( defined $tempdir ) {
         diag "Cleaning up $tempdir";
@@ -216,11 +216,17 @@ for my $chunk (@parts) {
     print $fh part($chunk);
     close $fh;
     push @uploaded_parts, $tempname;
-    
+
     my( $content_type, $ext ) = $flowjs->sniffContentType(\%info);
     if( exists $seen{1}) {
-        is $content_type, 'image/png', "Once we see the first chunk, we find the correct content type";
-        is $ext, 'png', "Once we see the first chunk, we find the correct extension";
+        if ( $flowjs->mime ) {
+            is $content_type, 'image/png', "Once we see the first chunk, we find the correct content type";
+            is $ext, 'png', "Once we see the first chunk, we find the correct extension";
+        }
+        else {
+            is $content_type, '', "Unknown content type or no MIME::Detect installed";
+            is $ext, '', "Unknown extension or no MIME::Detect installed";
+        }
     } else {
         is $content_type, undef, "Until we see the first chunk, we don't know the content type";
         is $ext, undef, "Until we see the first chunk, we don't know the extension";
@@ -305,9 +311,15 @@ for my $chunk (@parts, 2..parts) {
     close $fh;
     $uploaded_parts{ $tempname } = 1;
 
+
     my $res = $flowjs->disallowedContentType(\%info);
     if( exists $seen{1}) {
-        is $res, 'image/png', "Once we see the first chunk, we find the file is disallowed";
+        if ( $flowjs->mime ) {
+            is $res, 'image/png', "Once we see the first chunk, we find the file is disallowed";
+        }
+        else {
+            is $res, '1', "Unknown content type or no MIME::Detect installed";
+        }
     } else {
         is $res, undef, "Until we see the first chunk, we don't know if the file is disallowed";
     };

--- a/t/003_http_upload_flowjs.t
+++ b/t/003_http_upload_flowjs.t
@@ -1,7 +1,7 @@
 #!perl -w
 use strict;
 use warnings;
-use Test::More tests => 88;
+use Test::More tests => 89;
 use Data::Dumper;
 
 use HTTP::Upload::FlowJs;
@@ -533,6 +533,46 @@ subtest 'Check local size' => sub {
         \%info,
     );
     is_deeply( \@errors, ['Uploaded chunk [1] is too small ([0]) expect [768]'], 'Has errors on POST');
+
+};
+
+subtest 'Zero size' => sub {
+    my $flowjs = HTTP::Upload::FlowJs->new(
+        incomingDirectory => $tempdir,
+        minChunkSize => 0,
+        maxChunkSize => 1024,
+    );
+
+    my %info = (
+        flowChunkNumber => 1,
+        flowChunkSize => 1024,
+        flowFilename => 'IMG_7363.JPG',
+        flowIdentifier => '2226376-IMG_7363JPG',
+        flowRelativePath => 'IMG_7363.JPG',
+        flowTotalChunks => 1,
+        flowTotalSize => 0,
+        localChunkSize => 0,
+        flowCurrentChunkSize => 0,
+        file => $0,
+    );
+    my @errors = $flowjs->validateRequest(
+        'GET',
+        \%info,
+    );
+    is_deeply( \@errors, [], 'No errors on GET');
+
+    # Min chunk size
+    $flowjs = HTTP::Upload::FlowJs->new(
+        incomingDirectory => $tempdir,
+        minChunkSize => 1,
+        maxChunkSize => 1024,
+    );
+
+    @errors = $flowjs->validateRequest(
+        'GET',
+        \%info,
+    );
+    is_deeply( \@errors, ['Uploaded chunk [1] of file [IMG_7363.JPG] is too small [0], allowed is [1]'], 'Has errors on GET');
 
 };
 

--- a/t/004_js-config.t
+++ b/t/004_js-config.t
@@ -1,0 +1,57 @@
+#!perl -w
+use strict;
+use warnings;
+use Test::More tests => 3;
+use Data::Dumper;
+
+use HTTP::Upload::FlowJs;
+use File::Temp qw(tempdir);
+use ExtUtils::Command();
+
+my $tempdir = tempdir( );
+END {
+    if( defined $tempdir ) {
+        diag "Cleaning up $tempdir";
+        @ARGV = $tempdir;
+        ExtUtils::Command::rm_rf $tempdir;
+    };
+};
+
+my $flowjs = HTTP::Upload::FlowJs->new(
+    incomingDirectory => $tempdir,
+    forceChunkSize => 0,
+);
+
+is_deeply
+    $flowjs->jsConfig(addition => 'value'),
+    {
+        'chunkSize' => '524288',
+        'forceChunkSize' => 0,
+        'simultaneousUploads' => 3,
+        'testChunks' => 1,
+        'uploadMethod' => 'POST',
+        'withCredentials' => 1,
+        'addition' => 'value',
+    },
+    "jsConfig and chunkSize when forceChunkSize(0)";
+
+$flowjs = HTTP::Upload::FlowJs->new(
+    incomingDirectory => $tempdir,
+);
+
+is_deeply
+    $flowjs->jsConfig,
+    {
+        'chunkSize' => '1048576',
+        'forceChunkSize' => 1,
+        'simultaneousUploads' => 3,
+        'testChunks' => 1,
+        'uploadMethod' => 'POST',
+        'withCredentials' => 1,
+    },
+    "jsConfig and chunkSize when forceChunkSize(1)";
+
+
+ok $flowjs->jsConfigStr, "js str config";
+
+done_testing;


### PR DESCRIPTION
Hello!

Here is your module with less deps. It doesn't require addition modules (Text::CleanFragment and MIME::Detect are optional). Also it doesn't require last-perl-features. So it could be used on Perl 5.16+ without addition modules.
Also fix some issues (not proper checking chunk length).

Need to test behaviour on some circumstances (not sure it is problem in my project, in this module or flow.js): when in app you got all chunks, but app crashes on combining, then it doesn't allow to upload/combine chunks again.